### PR TITLE
chore: update osctl to v0.4.0-alpha.6

### DIFF
--- a/Casks/osctl.rb
+++ b/Casks/osctl.rb
@@ -1,6 +1,6 @@
 cask 'osctl' do
-    version '0.3.0-beta.0'
-    sha256 'cf6335fd21d9ec75e8164ee3b56b5499af14ca831dae3d7de3685724e269661c'
+    version '0.4.0-alpha.6'
+    sha256 'a4b31ca02438fa73a5e34992a831bc3afd79195f0e7b3bb217d035dc876ea4e0'
   
     url "https://github.com/talos-systems/talos/releases/download/v#{version}/osctl-darwin-amd64"
     name 'osctl'

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# Talos-systems Talos
+# Homebrew Talos
 
-## How do I install these formulae?
-`brew install talos-systems/talos/<formula>`
+## How do I install osctl?
 
-Or `brew tap talos-systems/talos` and then `brew install <formula>`.
+Installing osctl from this cask is simple:
 
-Or install via URL (which will not receive updates):
+- `brew tap talos-systems/talos`
+- `brew cask install osctl`
 
-```
-brew install https://raw.githubusercontent.com/talos-systems/homebrew-talos/master/Formula/<formula>.rb
-```
+## Resources
 
-## Documentation
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).


### PR DESCRIPTION
This PR brings in the latest pre-release of osctl v0.4.0

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>