### PR TITLE
chore: update to v0.14.0

### DIFF
--- a/Casks/talosctl.rb
+++ b/Casks/talosctl.rb
@@ -1,16 +1,16 @@
 # https://github.com/Homebrew/homebrew-cask/tree/master/doc/cask_language_reference
 
 cask "talosctl" do
-  version "0.13.4"
+  version "0.14.0"
 
   if Hardware::CPU.intel?
-    sha256 "b5b761ae92d5804f17c03ef29e8ccc03ffa7f5ddc28d7dd51038946fe04210cf"
+    sha256 "6aa825cea95208bbfd7a2fa1d7d4487ec15bc5feae95dbee97e481d5b1c37043"
     url "https://github.com/talos-systems/talos/releases/download/v#{version}/talosctl-darwin-amd64",
       verified: "github.com/talos-systems/talos/"
 
     binary "talosctl-darwin-amd64", target: "talosctl"
   else
-    sha256 "f3ee75cae98e57147e64376a236874cc76379836a63793b6fce53f84fdabc85b"
+    sha256 "8b7908904135e66cac7618d65e84c9570e15ad2155be168f44bde420668a8232"
     url "https://github.com/talos-systems/talos/releases/download/v#{version}/talosctl-darwin-arm64",
       verified: "github.com/talos-systems/talos/"
 


### PR DESCRIPTION
Upgrading talosctl to v0.14.0

Signed-off-by: Serge Logvinov <serge.logvinov@sinextra.dev>